### PR TITLE
Add `swift-bin`

### DIFF
--- a/build-pkgs
+++ b/build-pkgs
@@ -9,6 +9,7 @@ pkgs=(
   alac-git
   nqptp-git
   shairport-sync-git
+  swift-bin
   yay
 )
 

--- a/swift-bin/.gitignore
+++ b/swift-bin/.gitignore
@@ -1,0 +1,1 @@
+swift-bin

--- a/swift-bin/PKGBUILD
+++ b/swift-bin/PKGBUILD
@@ -5,11 +5,12 @@
 
 pkgname=swift-bin
 pkgver=5.8.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Binary builds of the Swift programming language"
 arch=('x86_64' 'aarch64')
 url="https://www.swift.org/"
 license=('apache')
+makedepends=('patchelf')
 depends=('libutil-linux' 'libxml2' 'ncurses')
 optdepends=('python36: required for REPL')
 options=('!strip')
@@ -26,6 +27,18 @@ source_aarch64=("https://download.swift.org/swift-$pkgver-release/ubuntu$_ubuntu
 
 sha256sums_x86_64=('SKIP')
 sha256sums_aarch64=('SKIP')
+
+prepare() {
+  case "$CARCH" in
+    x86_64) _suffix="";;
+    *) _suffix="-$CARCH";;
+  esac
+
+  # Patch the ncurses dependency to the one provided by the ncurses package
+  # TODO: This currently emits a few warnings for non-ELF executables, find a more elegant way to deal with them
+  find "${srcdir}/swift-$pkgver-RELEASE-ubuntu$_ubuntumajor.$_ubuntuminor$_suffix" -type f -executable -exec \
+    patchelf --replace-needed libncurses.so.6 libncursesw.so.6 {} \;
+}
 
 package() {
   case "$CARCH" in
@@ -44,6 +57,4 @@ package() {
 
   install -dm755 "${pkgdir}/etc/ld.so.conf.d"
   echo '/usr/lib/swift/lib/swift/linux' >> "${pkgdir}/etc/ld.so.conf.d/swift.conf"
-
-  # TODO: patchelf libncurses.so.6 -> libncursesw.so.6
 }

--- a/swift-bin/PKGBUILD
+++ b/swift-bin/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Susurri <susurrus dot silent at gmail dot com>
+# Contributor: Miten <git dot pub at icloud dot com>
+# Contributor: Ryan Gonzalez <rymg19 at gmail dot com>
+# Contributor: Frederic Bezies <fredbezies at gmail dot com>, youngunix <>
+
+pkgname=swift-bin
+pkgver=5.8.1
+pkgrel=1
+pkgdesc="Binary builds of the Swift programming language"
+arch=('x86_64' 'aarch64')
+url="https://www.swift.org/"
+license=('apache')
+depends=('libutil-linux' 'libxml2' 'ncurses')
+optdepends=('python36: required for REPL')
+options=('!strip')
+provides=('swift-language')
+replaces=('swift-language-bin')
+
+_ubuntumajor=22
+_ubuntuminor=04
+
+source_x86_64=("https://download.swift.org/swift-$pkgver-release/ubuntu$_ubuntumajor$_ubuntuminor/swift-$pkgver-RELEASE/swift-$pkgver-RELEASE-ubuntu$_ubuntumajor.$_ubuntuminor.tar.gz")
+source_aarch64=("https://download.swift.org/swift-$pkgver-release/ubuntu$_ubuntumajor$_ubuntuminor-aarch64/swift-$pkgver-RELEASE/swift-$pkgver-RELEASE-ubuntu$_ubuntumajor.$_ubuntuminor-aarch64.tar.gz")
+
+# TODO: Add sha256 checksums
+
+sha256sums_x86_64=('SKIP')
+sha256sums_aarch64=('SKIP')
+
+package() {
+  case "$CARCH" in
+    x86_64) _suffix="";;
+    *) _suffix="-$CARCH";;
+  esac
+
+  mkdir -p "${pkgdir}/usr/lib/swift"
+  cp -Ppr "${srcdir}/swift-$pkgver-RELEASE-ubuntu$_ubuntumajor.$_ubuntuminor$_suffix"/usr/* "${pkgdir}/usr/lib/swift"
+
+  # Symlink the desired binaries to /usr/bin
+  mkdir -p "${pkgdir}/usr/bin"
+  for bin in sourcekit-lsp swift swiftc; do
+    ln -s "/usr/lib/swift/bin/$bin" "${pkgdir}/usr/bin/$bin"
+  done
+
+  install -dm755 "${pkgdir}/etc/ld.so.conf.d"
+  echo '/usr/lib/swift/lib/swift/linux' >> "${pkgdir}/etc/ld.so.conf.d/swift.conf"
+
+  # TODO: patchelf libncurses.so.6 -> libncursesw.so.6
+}


### PR DESCRIPTION
This repackages the Ubuntu 22.04 package of the Swift compiler.

To do:

- [x] Patch `libncurses.so.6` dependency to `libncursesw.so.6` with `patchelf` 