### PR TITLE
Defer package compression to `build-db`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,12 @@ jobs:
         --workdir "/src/${{ github.repository }}"
         --entrypoint "/src/${{ github.repository }}"/docker-entrypoint
         ${{ matrix.image }}
+    - name: Build package database
+      run: >
+        docker run
+        --rm
+        --user "$(id -u):$(id -g)"
+        --mount type=bind,src="$PWD",dst="/src/${{ github.repository }}"
+        --workdir "/src/${{ github.repository }}"
+        --entrypoint "/src/${{ github.repository }}/build-db"
+        archlinux

--- a/build-db
+++ b/build-db
@@ -7,9 +7,15 @@ echo "==> Setting up database directory"
 dbdir="$PWD/db"
 mkdir -p "$dbdir"
 
-echo "==> Copying packages"
+echo "==> Compressing and copying packages"
 builddir="$PWD/build"
-cp "$builddir"/**.pkg.tar.* "$dbdir"
+(
+  cd "$builddir"
+  for pkg in *.pkg.tar.*; do
+    echo "Compressing $pkg"
+    zstd -o "$dbdir/$pkg.zst" "$builddir"
+  done
+)
 
 echo "==> Setting up a package database"
 repo-add "$dbdir/fwcd.db.tar.gz" "$dbdir"/*.pkg.tar.*

--- a/build-db
+++ b/build-db
@@ -13,7 +13,7 @@ builddir="$PWD/build"
   cd "$builddir"
   for pkg in *.pkg.tar.*; do
     echo "Compressing $pkg"
-    zstd -o "$dbdir/$pkg.zst" "$builddir"
+    zstd -o "$dbdir/$pkg.zst" "$pkg"
   done
 )
 

--- a/build-db
+++ b/build-db
@@ -11,7 +11,7 @@ echo "==> Compressing and copying packages"
 builddir="$PWD/build"
 (
   cd "$builddir"
-  for pkg in *.pkg.tar.*; do
+  for pkg in *.pkg.tar; do
     echo "Compressing $pkg"
     zstd -o "$dbdir/$pkg.zst" "$pkg"
   done

--- a/build-pkgs
+++ b/build-pkgs
@@ -27,13 +27,16 @@ for pkg in "${pkgs[@]}"; do
   (
     cd "$pkg"
 
-    # Build the package
-    PKGDEST="$builddir" makepkg -si --noconfirm
+    # Build the package (and compress later to speed things up under emulation)
+    PKGDEST="$builddir" PKGEXT='.pkg.tar' makepkg -si --noconfirm
 
     # Copy the generated .SRCINFO and (potentially) autobumped PKGBUILD
     buildsrcdir="$builddir/src/$pkg"
     mkdir -p "$buildsrcdir"
     makepkg --printsrcinfo > "$buildsrcdir/.SRCINFO"
     cp PKGBUILD "$buildsrcdir"
+
+    # Clean up the src and pkg directories to save space
+    rm -rf src pkg
   )
 done


### PR DESCRIPTION
This should speed up builds since compression no longer needs to happen under emulation.