### PR TITLE
Add scripts for bumping versions from AUR and regenerating derived info

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  schedule:
+  # Run every day at 3:20
+  - cron: '20 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Bump versions via the AUR
+      run: ./bump-versions
+    - name: Bump derived info
+      run: >
+        docker run
+        --rm
+        --user "$(id -u):$(id -g)"
+        --mount type=bind,src="$PWD",dst="/src/${{ github.repository }}"
+        --workdir "/src/${{ github.repository }}"
+        --entrypoint "/src/${{ github.repository }}/bump-derived"
+        archlinux:base-devel
+    - name: Set up Git config
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+    - name: Commit updates
+      run: |
+        git add -A
+        git commit -m "Bump packages ($(date '+%Y-%m-%d-%H-%M'))" || true 
+    - name: Push updates
+      run: git push

--- a/build-pkgs
+++ b/build-pkgs
@@ -28,12 +28,6 @@ for pkg in "${pkgs[@]}"; do
     # Build the package (and compress later to speed things up under emulation)
     PKGDEST="$builddir" PKGEXT='.pkg.tar' makepkg -si --noconfirm
 
-    # Copy the generated .SRCINFO and (potentially) autobumped PKGBUILD
-    buildsrcdir="$builddir/src/$pkg"
-    mkdir -p "$buildsrcdir"
-    makepkg --printsrcinfo > "$buildsrcdir/.SRCINFO"
-    cp PKGBUILD "$buildsrcdir"
-
     # Clean up the src and pkg directories to save space
     rm -rf src pkg
   )

--- a/build-pkgs
+++ b/build-pkgs
@@ -3,20 +3,18 @@
 set -e
 cd "$(dirname "$0")"
 
-# The packages to be built. Must be topologically sorted w.r.t dependencies.
-pkgs=(
-  k3s-bin
-  alac-git
-  nqptp-git
-  shairport-sync-git
-  swift-bin
-  yay
-)
-
 if [ "$(uname -s)" != Linux ]; then
   echo "$0 must run on Linux!"
   exit 1
 fi
+
+echo "==> Reading packages..."
+pkgs=()
+while IFS= read -r line; do
+  if [[ "$line" != "#"* ]] && [[ -n "$line" ]]; then
+    pkgs+=("$line")
+  fi
+done < packages.txt
 
 echo "==> Setting up build directory"
 builddir="$PWD/build"

--- a/build-pkgs
+++ b/build-pkgs
@@ -3,12 +3,12 @@
 set -e
 cd "$(dirname "$0")"
 
-if [ "$(uname -s)" != Linux ]; then
-  echo "$0 must run on Linux!"
+if ! command -v makepkg > /dev/null; then
+  echo "This script requires makepkg on your PATH!"
   exit 1
 fi
 
-echo "==> Reading packages..."
+echo "==> Reading packages"
 pkgs=()
 while IFS= read -r line; do
   if [[ "$line" != "#"* ]] && [[ -n "$line" ]]; then

--- a/bump-derived
+++ b/bump-derived
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+cd "$(dirname "$0")"
+
+for tool in updpkgsums strip git; do
+  if ! command -v "$tool" > /dev/null; then
+    echo "This script requires $tool on your PATH!"
+    exit 1
+  fi
+done
+
+echo "==> Reading packages"
+pkgs=()
+while IFS= read -r line; do
+  if [[ "$line" != "#"* ]] && [[ -n "$line" ]]; then
+    pkgs+=("$line")
+  fi
+done < packages.txt
+
+echo "==> Updating derived info"
+for pkg in "${pkgs[@]}"; do
+  echo "--> $pkg"
+  (
+    cd "$pkg"
+
+    updpkgsums
+    makepkg --nobuild --nodeps # Autobump VCS versions
+    makepkg --printsrcinfo > .SRCINFO
+  )
+done

--- a/bump-versions
+++ b/bump-versions
@@ -7,7 +7,7 @@ from typing import Optional
 import urllib.request
 
 def var_pattern(name: str) -> re.Pattern:
-    return re.compile(r'^(' + re.escape(name) + r'=["\']?)(?P<value>[^"\'\s]+)(["\']?)$', flags=re.MULTILINE)
+    return re.compile(r'^(?P<prefix>' + re.escape(name) + r'=["\']?)(?P<value>[^"\'\s]+)(?P<suffix>["\']?)$', flags=re.MULTILINE)
 
 ROOT = Path(__file__).resolve().parent
 PKGVER = var_pattern('pkgver')
@@ -34,7 +34,7 @@ def parse(pattern: re.Pattern, pkgbuild: str) -> Optional[str]:
     return m.group('value') if m else None
 
 def update(pattern: re.Pattern, new_value: str, pkgbuild: str) -> str:
-    return pattern.sub(f'\\1{new_value}\\3', pkgbuild)
+    return pattern.sub(r'\g<prefix>' + new_value + r'\g<suffix>', pkgbuild)
 
 def main():
     print('==> Reading packages')

--- a/bump-versions
+++ b/bump-versions
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+
+import re
+from typing import Optional
+import urllib.request
+
+def var_pattern(name: str) -> re.Pattern:
+    return re.compile(r'^(' + re.escape(name) + r'=["\']?)(?P<value>[^"\'\s]+)(["\']?)$', flags=re.MULTILINE)
+
+ROOT = Path(__file__).resolve().parent
+PKGVER = var_pattern('pkgver')
+PKGREL = var_pattern('pkgrel')
+
+def read_packages() -> list[str]:
+    with open(ROOT / 'packages.txt', 'r') as f:
+        return [l.strip() for l in f.readlines() if l.strip() and not l.startswith('#')]
+
+def fetch_aur_pkgbuild(pkg: str) -> str:
+    with urllib.request.urlopen(f'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h={pkg}') as f:
+        return f.read().decode('utf-8')
+
+def read_local_pkgbuild(pkg: str) -> str:
+    with open(ROOT / pkg / 'PKGBUILD', 'r') as f:
+        return f.read()
+
+def write_local_pkgbuild(pkgbuild: str, pkg: str) -> str:
+    with open(ROOT / pkg / 'PKGBUILD', 'w') as f:
+        return f.write(pkgbuild)
+
+def parse(pattern: re.Pattern, pkgbuild: str) -> Optional[str]:
+    m = pattern.search(pkgbuild)
+    return m.group('value') if m else None
+
+def update(pattern: re.Pattern, new_value: str, pkgbuild: str) -> str:
+    return pattern.sub(f'\\1{new_value}\\3', pkgbuild)
+
+def main():
+    print('==> Reading packages')
+    pkgs = read_packages()
+
+    print('==> Updating packages')
+    for pkg in pkgs:
+        aur_pkgbuild = fetch_aur_pkgbuild(pkg)
+        local_pkgbuild = read_local_pkgbuild(pkg)
+
+        local_pkgver = parse(PKGVER, local_pkgbuild)
+        local_pkgrel = parse(PKGREL, local_pkgbuild)
+
+        aur_pkgver = parse(PKGVER, aur_pkgbuild)
+        aur_pkgrel = parse(PKGREL, aur_pkgbuild)
+
+        local_verrel = f'{local_pkgver}-{local_pkgrel}'
+        aur_verrel = f'{aur_pkgver}-{aur_pkgrel}'
+
+        if local_verrel < aur_verrel:
+            print(f'{pkg}: {local_verrel} -> {aur_verrel}')
+
+            local_pkgbuild = update(PKGVER, aur_pkgver, local_pkgbuild)
+            local_pkgbuild = update(PKGREL, aur_pkgrel, local_pkgbuild)
+
+            write_local_pkgbuild(local_pkgbuild, pkg)
+        else:
+            print(f'{pkg}: {local_verrel} is up-to-date')
+
+if __name__ == '__main__':
+    main()

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -13,8 +13,14 @@ if [ -z "$BUILDER_UID" ] || [ -z "$BUILDER_GID" ]; then
   exit 1
 fi
 
-echo "==> Setting up builder user and group"
-groupadd -g "$BUILDER_GID" builder
+if [ $(getent group "$BUILDER_GID") ]; then
+  echo "==> Warning: Group with GID $BUILDER_GID already exists, the existing group will be used"
+else
+  echo "==> Setting up builder group (GID: $BUILDER_GID)"
+  groupadd -g "$BUILDER_GID" builder
+fi
+
+echo "==> Setting up builder user (UID: $BUILDER_UID)"
 useradd -m -u "$BUILDER_UID" -g "$BUILDER_GID" builder
 
 echo "==> Installing system dependencies"

--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,7 @@
+# The packages to be built. Must be topologically sorted w.r.t dependencies.
+k3s-bin
+alac-git
+nqptp-git
+shairport-sync-git
+swift-bin
+yay


### PR DESCRIPTION
### Fixes #8

This adds a script for updating the package versions from the AUR and another one for regenerating derived information, such as checksums, `.SRCINFO` files and VCS versions.

Additionally it moves the canonical list of packages into a separate file, named `packages.txt`.