### PR TITLE
Keep building other packages after errors

### DIFF
--- a/build-pkgs
+++ b/build-pkgs
@@ -26,7 +26,11 @@ for pkg in "${pkgs[@]}"; do
     cd "$pkg"
 
     # Build the package (and compress later to speed things up under emulation)
-    PKGDEST="$builddir" PKGEXT='.pkg.tar' makepkg -si --noconfirm --nocheck
+    if PKGDEST="$builddir" PKGEXT='.pkg.tar' makepkg -si --noconfirm --nocheck; then
+      echo "$pkg built successfully"
+    else
+      echo "::warning title={$pkg could not be built}::See the build logs for details"
+    fi
 
     # Clean up the src and pkg directories to save space
     rm -rf src pkg


### PR DESCRIPTION
Fixes #16 by only emitting a warning (instead of exiting the script) for failed package builds.