### PR TITLE
Add `github-actions-bin` package

### DIFF
--- a/github-actions-bin/PKGBUILD
+++ b/github-actions-bin/PKGBUILD
@@ -1,0 +1,78 @@
+# Maintainer  : Samuel Williams <samuel@oriontransfer.net>
+# Contributor : Edvinas Valatka <edacval@gmail.com>
+# Contributor : Jingbei Li <i@jingbei.li>
+
+_pkgname=github-actions
+pkgname=${_pkgname}-bin
+pkgver=2.317.0
+pkgrel=1
+pkgdesc='GitHub Actions self-hosted runner tools.'
+arch=('x86_64' 'armv6h' 'armv7h' 'aarch64')
+url='https://github.com/actions/runner'
+license=('MIT')
+
+OPTIONS=(!strip !docs libtool emptydirs)
+
+install="${pkgname}.install"
+
+provides=($_pkgname)
+conflicts=($_pkgname)
+_common_source=(github-actions.service github-actions.tmpfiles github-actions.sysusers)
+source=(
+  "https://github.com/actions/runner/releases/download/v$pkgver/actions-runner-linux-x64-$pkgver.tar.gz"
+  ${_common_source[@]}
+)
+source_armv6h=(
+  "https://github.com/actions/runner/releases/download/v$pkgver/actions-runner-linux-arm-$pkgver.tar.gz"
+  ${_common_source[@]}
+)
+source_armv7h=(${source_armv6h[@]})
+source_aarch64=(
+  "https://github.com/actions/runner/releases/download/v$pkgver/actions-runner-linux-arm64-$pkgver.tar.gz"
+  ${_common_source[@]}
+)
+
+sha512sums=(
+  'd5e56dd8f6cb412b6c278455bdcda3afb108c0e2d5d8a7146ac228d879dd0b771076c404eef685a024f85cfe8824b1cb9ac7917ace693e5e8a77076e6a148637'
+  'c61a725424596df6e08f45447967ceeb711a1ba44d8ccf05733ff0e9ba1931e0171b002b0ae51c8914b7041ad3c572f9678567f38fa82792141036a22022cab5'
+  '15136f3256028f47ec246f7aa0b95a84c948073f236944322db4a891598423d68d737f09986393bd531dabbf53f44bdcab1519c1dd2bc4e36102580fdcd3e22b'
+  '49329a3c65987f7bb219100b41deb33fcbc64f5e6424c4e31d580e2fbd408545d2d4a990c5511a3625250bd37ad7d13496cfd152ffd20de04fd24250242088d4'
+)
+sha512sums_armv6h=(
+  '58b3120703ffaa6006f9a226047349948857230daad9c0d4a7235818b6cd28c5f2fcb3a6b879b04f4e3acd423c8110be84765237b39fa1e639eafc22348d3084'
+  'c61a725424596df6e08f45447967ceeb711a1ba44d8ccf05733ff0e9ba1931e0171b002b0ae51c8914b7041ad3c572f9678567f38fa82792141036a22022cab5'
+  '15136f3256028f47ec246f7aa0b95a84c948073f236944322db4a891598423d68d737f09986393bd531dabbf53f44bdcab1519c1dd2bc4e36102580fdcd3e22b'
+  '49329a3c65987f7bb219100b41deb33fcbc64f5e6424c4e31d580e2fbd408545d2d4a990c5511a3625250bd37ad7d13496cfd152ffd20de04fd24250242088d4'
+)
+sha512sums_armv7h=(
+  '58b3120703ffaa6006f9a226047349948857230daad9c0d4a7235818b6cd28c5f2fcb3a6b879b04f4e3acd423c8110be84765237b39fa1e639eafc22348d3084'
+  'c61a725424596df6e08f45447967ceeb711a1ba44d8ccf05733ff0e9ba1931e0171b002b0ae51c8914b7041ad3c572f9678567f38fa82792141036a22022cab5'
+  '15136f3256028f47ec246f7aa0b95a84c948073f236944322db4a891598423d68d737f09986393bd531dabbf53f44bdcab1519c1dd2bc4e36102580fdcd3e22b'
+  '49329a3c65987f7bb219100b41deb33fcbc64f5e6424c4e31d580e2fbd408545d2d4a990c5511a3625250bd37ad7d13496cfd152ffd20de04fd24250242088d4'
+)
+sha512sums_aarch64=(
+  '13e3d5c0c9568fc37f262233f3d399b199ee709d3e65d521e981984fb2bfe10646bcf0f0d08c826886ff2a36be68a949f632922833fb83c454ba4314d4b0a6c3'
+  'c61a725424596df6e08f45447967ceeb711a1ba44d8ccf05733ff0e9ba1931e0171b002b0ae51c8914b7041ad3c572f9678567f38fa82792141036a22022cab5'
+  '15136f3256028f47ec246f7aa0b95a84c948073f236944322db4a891598423d68d737f09986393bd531dabbf53f44bdcab1519c1dd2bc4e36102580fdcd3e22b'
+  '49329a3c65987f7bb219100b41deb33fcbc64f5e6424c4e31d580e2fbd408545d2d4a990c5511a3625250bd37ad7d13496cfd152ffd20de04fd24250242088d4'
+)
+
+package() {
+  depends=(sudo)
+  mkdir -p "$pkgdir"/var/lib/$_pkgname
+
+  # Useless on pacman-based distributions
+  rm -f "$srcdir"/bin/installdependencies.sh
+
+  cp -r -t "$pkgdir"/var/lib/$_pkgname "$srcdir"/{bin,externals,*.sh}
+
+  # also see github-actions.tmpfiles
+  chmod 0775 "$pkgdir"/var/lib/$_pkgname
+
+  # make ldd happy
+  chmod +x "$pkgdir"/var/lib/$_pkgname/bin/*.so
+
+  install -Dm644 "$srcdir"/$_pkgname.tmpfiles "${pkgdir}"/usr/lib/tmpfiles.d/$_pkgname.conf
+  install -Dm644 "$srcdir"/$_pkgname.sysusers "${pkgdir}"/usr/lib/sysusers.d/$_pkgname.conf
+  install -Dm644 "$srcdir"/$_pkgname.service  "${pkgdir}"/usr/lib/systemd/system/$_pkgname.service
+}

--- a/github-actions-bin/github-actions-bin.install
+++ b/github-actions-bin/github-actions-bin.install
@@ -1,0 +1,11 @@
+pre_remove() {
+  if systemctl -q is-enabled $_pkgname.service; then
+    systemctl disable $_pkgname.service
+  fi
+}
+
+post_remove() {
+  echo
+  echo "Remove $_pkgname user and this HOME /var/lib/$_pkgname manually, if not needed anymore."
+  echo
+}

--- a/github-actions-bin/github-actions.service
+++ b/github-actions-bin/github-actions.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=GitHub Actions Listener Daemon
+
+[Service]
+User=github-actions
+WorkingDirectory=~
+Type=exec
+ExecStart=/var/lib/github-actions/externals/node16/bin/node bin/RunnerService.js
+KillMode=process
+KillSignal=SIGINT
+TimeoutStopSec=5min
+
+[Install]
+WantedBy=multi-user.target

--- a/github-actions-bin/github-actions.sysusers
+++ b/github-actions-bin/github-actions.sysusers
@@ -1,0 +1,1 @@
+u github-actions - "Github Actions runner" /var/lib/github-actions -

--- a/github-actions-bin/github-actions.tmpfiles
+++ b/github-actions-bin/github-actions.tmpfiles
@@ -1,0 +1,4 @@
+# Give write to HOME permision for runner
+z /var/lib/github-actions 0775 root github-actions
+Z /var/lib/github-actions/bin 0775 root github-actions
+Z /var/lib/github-actions/externals 0775 root github-actions

--- a/packages.txt
+++ b/packages.txt
@@ -1,5 +1,6 @@
 # The packages to be built. Must be topologically sorted w.r.t dependencies.
 k3s-bin
+github-actions-bin
 alac-git
 nqptp-git
 shairport-sync-git


### PR DESCRIPTION
This adds the [`github-actions-bin`](https://aur.archlinux.org/packages/github-actions-bin) package from the AUR, which is a self-hosted runner for GitHub Actions CI.